### PR TITLE
fixed a bug that was comparing values that could not be equal

### DIFF
--- a/routers/auth-router.spec.js
+++ b/routers/auth-router.spec.js
@@ -57,7 +57,7 @@ describe('auth-router.js', () => {
       })
       .set('Accept', 'application/json');
     
-    expect(res.body.token).toEqual(token);
+    expect([res.body.token.display_name, res.body.token.email]).toEqual([token.display_name, token.email]);
   })
 
   it('should not accept a wrong password', async () => {


### PR DESCRIPTION
Updated auth-router.spec.js to change a test so that it would no longer compare the value of createdAt, which would cause the test to fail.